### PR TITLE
Added support for ECDSA and ED25519 public keys

### DIFF
--- a/lib/Parse/SSH2/PublicKey.pm
+++ b/lib/Parse/SSH2/PublicKey.pm
@@ -70,8 +70,8 @@ has encryption => (
     is  => 'ro',
     isa => sub {
         my $enc = shift;
-        confess "must be 'ssh-rsa' or 'ssh-dss'"
-            unless grep { $enc eq $_ } qw/ssh-rsa ssh-dss/;
+        confess "must be 'ssh-rsa', 'ssh-dss', 'ecdsa-sha2-nistp256' or 'ssh-ed25519'"
+            unless grep { $enc eq $_ } qw/ssh-rsa ssh-dss  ecdsa-sha2-nistp256 ssh-ed25519/;
     },
     default => sub { '' },
 );
@@ -114,7 +114,7 @@ sub parse {
         my $entire_key;
 
         # OpenSSH format -- all on one line.
-        if ( $data =~ m%((ssh-rsa|ssh-dss)\ ([A-Z0-9a-z/+=]+)\s*([^\n]*))%gsmx ) {
+        if ( $data =~ m%((ssh-rsa|ssh-dss|ecdsa-sha2-nistp256|ssh-ed25519)\ ([A-Z0-9a-z/+=]+)\s*([^\n]*))%gsmx ) {
             $entire_key = $1;
 
             # TODO: pull encryption from base64 key data, not here... just to be safe.

--- a/t/openssh-pubkey.t
+++ b/t/openssh-pubkey.t
@@ -2,7 +2,7 @@
 
 use strict;
 use warnings;
-use Test::More tests => 11;
+use Test::More tests => 21;
 
 use_ok('Parse::SSH2::PublicKey');
 
@@ -10,6 +10,8 @@ my (@keys, $k);
 
 my $openssh_rsa_pub = q{ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDMGTizB5naTwPe9bi1FHyj0FAaPsIS0UmNO31g3WBK9AtIYQbZGRjiHqg28jYOHRd3EinASn40YXS4IoGPOb3BD//Bj8dMxQ0oQTHVsCx/Y/GrGBl7+tIHlknpMasf97WkJh4+k8P4amd6lPObUV0s9JaWx2KUJPui3bh7ymcXKzi90NT+zh5wRbGczbKXa05u+2DuofdgQC7PK6xPxwgGsOF2UlpuEPW2705umhkCQ1sOmQvwCVH9zQJk9jfuqE55gAAOewijDWcdu39v+m5OxITvMydpI6tJJY9QaptJdt0ORo8htfKBDH025nCEtPn2lwbEQO6X6zpDOzwxE4G3 sshuser@host};
 my $openssh_dsa_pub = q{ssh-dss AAAAB3NzaC1kc3MAAACBAKxe0WtI19h2zNNJBbh0C52lGcs7WUvs6jlktWjd1anOVBwYEGIPUbcU0Frq8kyr9daJv44FEClEougVrz3uiMnDAKpD7rJ32/oc94c7YlVF/SjTz2fLA4n0nA9d/lkC1X6Tfj5JDwuMPURi1mNZlKZ9EhyQ916Sj1IakvnmQ9BNAAAAFQC706Ie1+oDglySpaHIIUNnDMAUtwAAAIAaCVEpV/IeEXvWtDhH7MzZMTn1JbhOzgIehuXX0XpGRI9q+OI7Khw7JmvhFBCTYfYpK3PK9bBMHiX8b1tNaorMc2UNQlJzJzjR2hTJgPJ8DgG/RyXbqpkUruXp8IyD4i+NSl1xNFEKentL32d+I4HshWO9n9XVH225GQrrVnZ/OgAAAIBHa5XkFIFKxiJxNurFYX4/X0a2IiaHGxO5ot6/73Atme7+3JhQvteR19d67bE1f7CXDl56el2oMHNrkpcPZkBWP6CnG7bLa65tN23sXjkbrV7HqZdCMZv4drzRtYo+I6MHNPsMmwGToOYeeL3JQH/EIUeXYLXlIw9+LM6P/k5iag== My 1024-bit DSA key};
+my $openssh_ecdsa_pub = q{ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBMK1IxOZEKvh96sRuyuK9/Cf3iRLTQeXBx6JcURpoZOeFjgHQwNXccxWAwzheIEpqSAEYKTYs2BW0M/Kc1FC7ps= My ECDSA key};
+my $openssh_ed25519_pub = q{ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIEg0qEPVdgsctK3bY+xnIMUYqlGvA8mgKulekNlxG/jB My Ed25519 key};
 
 # parse openssh rsa key
 @keys = Parse::SSH2::PublicKey->parse( $openssh_rsa_pub );
@@ -31,3 +33,22 @@ is( $k->comment, 'My 1024-bit DSA key', 'OpenSSH DSA comment parsed.' );
 is( $k->key, 'AAAAB3NzaC1kc3MAAACBAKxe0WtI19h2zNNJBbh0C52lGcs7WUvs6jlktWjd1anOVBwYEGIPUbcU0Frq8kyr9daJv44FEClEougVrz3uiMnDAKpD7rJ32/oc94c7YlVF/SjTz2fLA4n0nA9d/lkC1X6Tfj5JDwuMPURi1mNZlKZ9EhyQ916Sj1IakvnmQ9BNAAAAFQC706Ie1+oDglySpaHIIUNnDMAUtwAAAIAaCVEpV/IeEXvWtDhH7MzZMTn1JbhOzgIehuXX0XpGRI9q+OI7Khw7JmvhFBCTYfYpK3PK9bBMHiX8b1tNaorMc2UNQlJzJzjR2hTJgPJ8DgG/RyXbqpkUruXp8IyD4i+NSl1xNFEKentL32d+I4HshWO9n9XVH225GQrrVnZ/OgAAAIBHa5XkFIFKxiJxNurFYX4/X0a2IiaHGxO5ot6/73Atme7+3JhQvteR19d67bE1f7CXDl56el2oMHNrkpcPZkBWP6CnG7bLa65tN23sXjkbrV7HqZdCMZv4drzRtYo+I6MHNPsMmwGToOYeeL3JQH/EIUeXYLXlIw9+LM6P/k5iag==', 'OpenSSH DSA key parsed' );
 undef $k; undef @keys;
 
+# parse openssh dsa keys...
+@keys = Parse::SSH2::PublicKey->parse( $openssh_ecdsa_pub );
+$k    = $keys[0];
+isa_ok( $k, 'Parse::SSH2::PublicKey', 'Got Parse::SSH2::PublicKey object' );
+is ( $k->type, 'public', 'Public key' );
+is ( $k->encryption, 'ecdsa-sha2-nistp256', 'ECDSA key' );
+is( $k->comment, 'My ECDSA key', 'OpenSSH DSA comment parsed.' );
+is( $k->key, 'AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBMK1IxOZEKvh96sRuyuK9/Cf3iRLTQeXBx6JcURpoZOeFjgHQwNXccxWAwzheIEpqSAEYKTYs2BW0M/Kc1FC7ps=', 'OpenSSH ECDSA key parsed' );
+undef $k; undef @keys;
+
+# parse openssh dsa keys...
+@keys = Parse::SSH2::PublicKey->parse( $openssh_ed25519_pub );
+$k    = $keys[0];
+isa_ok( $k, 'Parse::SSH2::PublicKey', 'Got Parse::SSH2::PublicKey object' );
+is ( $k->type, 'public', 'Public key' );
+is ( $k->encryption, 'ssh-ed25519', 'ED25519 key' );
+is( $k->comment, 'My Ed25519 key', 'OpenSSH ED25519 comment parsed.' );
+is( $k->key, 'AAAAC3NzaC1lZDI1NTE5AAAAIEg0qEPVdgsctK3bY+xnIMUYqlGvA8mgKulekNlxG/jB', 'OpenSSH ED25519 key parsed' );
+undef $k; undef @keys;

--- a/t/parse.t
+++ b/t/parse.t
@@ -22,6 +22,10 @@ Qf2rGA0G/rKNx5r1X7tw2bIfKymVDUV/maTwPwXrQrJ/JHQjONREqmNJpq+EkugqR46Kbr
 3NVMGXvl8g63t1IKXNcPAZ
 ---- END SSH2 PUBLIC KEY ----
 };
+my $openssh_ecdsa_pub = q{ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBMK1IxOZEKvh96sRuyuK9/Cf3iRLTQeXBx6JcURpoZOeFjgHQwNXccxWAwzheIEpqSAEYKTYs2BW0M/Kc1FC7ps= My ECDSA key
+};
+my $openssh_ed25519_pub = q{ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIEg0qEPVdgsctK3bY+xnIMUYqlGvA8mgKulekNlxG/jB My Ed25519 key
+};
 
 # parse secsh
 @keys = Parse::SSH2::PublicKey->parse( $secsh_pub );
@@ -55,8 +59,8 @@ is ( $k->type, 'public', 'Public key' );
 undef $k; undef @keys;
 
 # parse different pubkey formats in the SAME FILE!!
-my $data = $openssh_rsa_pub . $openssh_dsa_pub .  $secsh_pub;
+my $data = $openssh_rsa_pub . $openssh_dsa_pub .  $secsh_pub . $openssh_ecdsa_pub . $openssh_ed25519_pub;
 @keys = Parse::SSH2::PublicKey->parse($data);
-is( @keys, 3, "Correct number of keys parsed from input" );
+is( @keys, 5, "Correct number of keys parsed from input" );
 
 


### PR DESCRIPTION
Hi,

This patch adds support for openssh ECDSA and EC25519 public keys, with some of the tests
(specifically the read of both openssh and secsh format strings) updated to match.
This was tested on some keys generated by and converted with openssh 7.4p1 on OS X.

